### PR TITLE
Fix for running under linux

### DIFF
--- a/CascLib/LocalIndexHandler.cs
+++ b/CascLib/LocalIndexHandler.cs
@@ -119,7 +119,7 @@ namespace CASCLib
 
             for (int i = 0; i < 0x10; ++i)
             {
-                var files = Directory.EnumerateFiles(Path.Combine(config.BasePath, dataPath), string.Format("{0:X2}*.idx", i));
+                var files = Directory.EnumerateFiles(Path.Combine(config.BasePath, dataPath), string.Format("{0:x2}*.idx", i));
 
                 if (files.Count() > 0)
                     latestIdx.Add(files.Last());


### PR DESCRIPTION
`string.Format("{0:X2}*.idx", i)` is looking for `00*.idx`, `01*.idx`, …, `0E*.idx`, `0F*.idx` which is causing it to miss files while running under Linux.

`string.Format("{0:x2}*.idx", i)` will look for `00*.idx`, `01*.idx`, …, `0e*.idx`, `0f*.idx`.

This was only checked against Heroes of the Storm and not any other game.
